### PR TITLE
DEVAI-241: convert the application-gitops Job template to bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ At the moment one template has helm chart support and this is the [chatbot appli
 
 ## Gitops
 
-The gitops component, handled by ArgoCD for the RHDH case, is replaced by the `application_gitops` project. Therefore, post application deployment a kubernetes Job is taking care of the github application repository creation. The source code is [here](https://github.com/redhat-ai-dev/developer-images/tree/main/helm-charts/application-gitops)
+The gitops component, handled by ArgoCD for the RHDH case, is replaced by a Kubernetes Job created by the Helm chart, where this Job:
+- Creates the GitHub repository for the application.
+- Copies the application source code into the new repository.
+- Copies the Tekton Pipelines As Code PipelineRun/Pipeline/Task that build new images for the application as pull requests 
+are merged and updates the Deployment of the application with the new version of the image.
+- Commits these changes and pushes the commit to the preferred branch of the new repository.
+
+The source code is [here](charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml).
 
 ## OpenShift Pipelines
 

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -69,10 +69,10 @@ Below is a table of each value used to configure this chart. Note:
 ### Gitops
 
 | Value                      | Description                                                                                                                                         | Default                        | Additional Information |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ---------------------- |
+| -------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------| ---------------------- |
 | `gitops.gitSecretName`     | The name of the Secret containing the required Github token.                                                                                        | `git-secrets`                  |                        |
 | `gitops.gitSecretKeyToken` | The name of the Secret's key with the Github token value.                                                                                           | `GITHUB_TOKEN`                 |                        |
-| `gitops.githubOrgName`     | `[REQUIRED]` The Github Organization name that the chatbot application repository will be created into                                              |                                |                        |
+| `gitops.githubOrgName`     | `[REQUIRED]` The Github Organization name that the chatbot application repository will be created into.                                             |                                |                        |
 | `gitops.gitSourceRepo`     | The Github Repository with the contents of the ai-lab sample chatbot application. It must be either the `redhat-ai-dev/ai-lab-samples` or its fork. | `redhat-ai-dev/ai-lab-samples` |
 | `gitops.gitDefaultBranch`  | The default branch for the chatbot application Github repository.                                                                                   | `main`                         |                        |
 | `gitops.quayAccountName`   | `[REQUIRED]` The quay.io account that the application image will be pushed.                                                                         |                                |                        |

--- a/charts/ai-software-templates/chatbot/templates/app-config.yaml
+++ b/charts/ai-software-templates/chatbot/templates/app-config.yaml
@@ -15,3 +15,4 @@ data:
   GITHUB_TETKON_SOURCE_REPO: "redhat-ai-dev/ai-lab-helm-charts"
   GITHUB_DEFAULT_BRANCH: "{{ .Values.gitops.gitDefaultBranch }}"
   QUAY_ACCOUNT_NAME: "{{ .Values.gitops.quayAccountName }}"
+  GH_VERSION: "2.62.0"

--- a/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
+++ b/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
@@ -17,11 +17,12 @@ spec:
             - -c
             - |
               #!/usr/bin/env bash
+              set -o nounset
+              set -o pipefail
               cd /tmp || exit
-              wget https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_linux_amd64.tar.gz
-              gunzip gh_2.62.0_linux_amd64.tar.gz
-              tar xf gh_2.62.0_linux_amd64.tar
-              export PATH=./gh_2.62.0_linux_amd64/bin:$PATH
+              wget https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_linux_amd64.tar.gz || exit
+              tar xzf gh_2.62.0_linux_amd64.tar.gz
+              export PATH=$(pwd)/gh_2.62.0_linux_amd64/bin:$PATH
               export SOURCE_REPO_APP_CONTENT_PATH="chatbot"
               export SOURCE_TEKTON_REPO_CONTENT_PATH="pac/pipelineRuns"
               export TEKTON_FILE_APP_NAME_REPLACEMENT="application_name_replace"
@@ -43,7 +44,7 @@ spec:
               gh auth login -p https
               gh auth setup-git --hostname=github.com
 
-              gh repo view "$GH_REPO" 2> /dev/null
+              gh repo view "$GH_REPO" --json id 2> /dev/null
 
               return_code=$?
 
@@ -51,7 +52,13 @@ spec:
                 echo Repo "$GH_REPO" already exists
                 exit 0
               else
-                gh repo create "$GH_REPO" --public --gitignore Python --license Apache-2.0
+                gh repo create "$GH_REPO" --public --gitignore Python --license Apache-2.0 || exit
+                gh repo view "$GH_REPO" --json id 2> /dev/null
+                return_code=$?
+                if [ $return_code != 0 ]; then
+                  echo Repo create of "$GH_REPO" could not be confirmed
+                  exit $return_code
+                fi
               fi
 
               gh repo clone "$GITHUB_SOURCE_REPO" app-source -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch

--- a/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
+++ b/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
@@ -37,11 +37,7 @@ spec:
                  tar cf - ./* | (cd ../../"$APP_NAME" || exit; tar xf -)
                  cd ../../tekton-source/pac/pipelineRuns/.tekton || exit
                  tar cf - ./* | (cd ../../../../"$APP_NAME"/.tekton || exit; tar xf -)
-                 cd ../../pipelines || exit
-                 tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
-                 cd ../tasks || exit
-                 tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
-                 cd ../../../"$APP_NAME" || exit
+                 cd ../../../../"$APP_NAME" || exit
               }
 
               cd /tmp || exit
@@ -97,19 +93,7 @@ spec:
                   echo "$same"
                   exit 1
                 fi
-                same=$(diff existing/.tekton/docker-build-ai-software-templates-chart.yaml "$APP_NAME"/.tekton/docker-build-ai-software-templates-chart.yaml)
-                return_code=$?
-                if [ $return_code != 0 ]; then
-                  echo "$same"
-                  exit 1
-                fi
                 same=$(diff existing/.tekton/docker-push.yaml "$APP_NAME"/.tekton/docker-push.yaml)
-                return_code=$?
-                if [ $return_code != 0 ]; then
-                  echo "$same"
-                  exit 1
-                fi
-                same=$(diff existing/.tekton/update-deployment.yaml "$APP_NAME"/.tekton/update-deployment.yaml)
                 return_code=$?
                 if [ $return_code != 0 ]; then
                   echo "$same"

--- a/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
+++ b/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
@@ -12,7 +12,78 @@ spec:
     spec:
       containers:
         - name: repo-creator
-          image: quay.io/redhat-ai-dev/helm-chart-application-gitops:latest
+          command:
+            - /bin/bash
+            - -c
+            - |
+              #!/usr/bin/env bash
+              cd /tmp || exit
+              wget https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_linux_amd64.tar.gz
+              gunzip gh_2.62.0_linux_amd64.tar.gz
+              tar xf gh_2.62.0_linux_amd64.tar
+              export PATH=./gh_2.62.0_linux_amd64/bin:$PATH
+              export SOURCE_REPO_APP_CONTENT_PATH="chatbot"
+              export SOURCE_TEKTON_REPO_CONTENT_PATH="pac/pipelineRuns"
+              export TEKTON_FILE_APP_NAME_REPLACEMENT="application_name_replace"
+              export TEKTON_FILE_APP_NAMESPACE_REPLACEMENT="application_namespace_replace"
+              export TEKTON_FILE_QUAY_ACCOUNT_REPLACEMENT="quay_account_replace"
+              echo APP_NAME is "$APP_NAME"
+              echo APP_NAMESPACE is "$APP_NAMESPACE"
+              echo GITHUB_ORG_NAME is "$GITHUB_ORG_NAME"
+              echo GITHUB_SOURCE_REPO is "$GITHUB_SOURCE_REPO"
+              echo GITHUB_TETKON_SOURCE_REPO is "$GITHUB_TETKON_SOURCE_REPO"
+              echo GITHUB_DEFAULT_BRANCH is "$GITHUB_DEFAULT_BRANCH"
+              echo QUAY_ACCOUNT_NAME is "$QUAY_ACCOUNT_NAME"
+
+              export GH_TOKEN=$GITHUB_TOKEN
+              export GH_REPO="github.com/$GITHUB_ORG_NAME/$APP_NAME"
+
+              export HOME=/tmp
+
+              gh auth login -p https
+              gh auth setup-git --hostname=github.com
+
+              gh repo view "$GH_REPO" 2> /dev/null
+
+              return_code=$?
+
+              if [ $return_code == 0 ]; then
+                echo Repo "$GH_REPO" already exists
+                exit 0
+              else
+                gh repo create "$GH_REPO" --public --gitignore Python --license Apache-2.0
+              fi
+
+              gh repo clone "$GITHUB_SOURCE_REPO" app-source -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch
+              gh repo clone "$GITHUB_TETKON_SOURCE_REPO" tekton-source -- --no-tags --single-branch
+              gh repo clone "$GH_REPO" "$APP_NAME" -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch
+
+              mkdir -p "$APP_NAME"/.tekton
+
+              cd tekton-source/pac/pipelineRuns/.tekton || exit
+              sed -i 's@'"$TEKTON_FILE_APP_NAME_REPLACEMENT"'@'"$APP_NAME"'@g' docker-push.yaml
+              sed -i 's@'"$TEKTON_FILE_APP_NAMESPACE_REPLACEMENT"'@'"$APP_NAMESPACE"'@g' docker-push.yaml
+              sed -i 's@'"$TEKTON_FILE_QUAY_ACCOUNT_REPLACEMENT"'@'"$QUAY_ACCOUNT_NAME"'@g' docker-push.yaml
+              cd - || exit
+
+              cd app-source/chatbot || exit
+              tar cf - ./* | (cd ../../"$APP_NAME" || exit; tar xf -)
+              cd ../../tekton-source/pac/pipelineRuns/.tekton || exit
+              tar cf - ./* | (cd ../../../../"$APP_NAME"/.tekton || exit; tar xf -)
+              cd ../../pipelines || exit
+              tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
+              cd ../tasks || exit
+              tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
+              cd ../../../"$APP_NAME" || exit
+
+              git config user.email  "{{ .Values.gitops.gitAuthorEmail }}"
+              git config user.name  "{{ .Values.gitops.gitAuthorName }}"
+
+              git status -s | grep "??" | awk '{ print $2 }' | xargs -l -r git add
+              git commit -a -m initial-commit
+              git push origin "$GITHUB_DEFAULT_BRANCH"
+
+          image: registry.redhat.io/openshift4/ose-docker-builder-rhel9:v4.16
           env:
             - name: GITHUB_TOKEN
               valueFrom:

--- a/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
+++ b/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
@@ -19,6 +19,31 @@ spec:
               #!/usr/bin/env bash
               set -o nounset
               set -o pipefail
+
+              setup_data() {
+                 gh repo clone "$GITHUB_SOURCE_REPO" app-source -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch
+                 gh repo clone "$GITHUB_TETKON_SOURCE_REPO" tekton-source -- --no-tags --single-branch
+                 gh repo clone "$GH_REPO" "$APP_NAME" -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch
+
+                 mkdir -p "$APP_NAME"/.tekton
+
+                 cd tekton-source/pac/pipelineRuns/.tekton || exit
+                 sed -i 's@'"$TEKTON_FILE_APP_NAME_REPLACEMENT"'@'"$APP_NAME"'@g' docker-push.yaml
+                 sed -i 's@'"$TEKTON_FILE_APP_NAMESPACE_REPLACEMENT"'@'"$APP_NAMESPACE"'@g' docker-push.yaml
+                 sed -i 's@'"$TEKTON_FILE_QUAY_ACCOUNT_REPLACEMENT"'@'"$QUAY_ACCOUNT_NAME"'@g' docker-push.yaml
+                 cd - || exit
+
+                 cd app-source/chatbot || exit
+                 tar cf - ./* | (cd ../../"$APP_NAME" || exit; tar xf -)
+                 cd ../../tekton-source/pac/pipelineRuns/.tekton || exit
+                 tar cf - ./* | (cd ../../../../"$APP_NAME"/.tekton || exit; tar xf -)
+                 cd ../../pipelines || exit
+                 tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
+                 cd ../tasks || exit
+                 tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
+                 cd ../../../"$APP_NAME" || exit
+              }
+
               cd /tmp || exit
               wget https://github.com/cli/cli/releases/download/v"$GH_VERSION"/gh_"$GH_VERSION"_linux_amd64.tar.gz || exit
               tar xzf gh_"$GH_VERSION"_linux_amd64.tar.gz
@@ -50,7 +75,47 @@ spec:
               return_code=$?
 
               if [ $return_code == 0 ]; then
-                echo Repo "$GH_REPO" already exists
+                echo Repo "$GH_REPO" already exists, checking if contents are OK
+                setup_data
+                cd $HOME || exit
+                gh repo clone "$GH_REPO" existing -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch || exit
+                same=$(diff existing/Containerfile "$APP_NAME"/Containerfile)
+                return_code=$?
+                if [ $return_code != 0 ]; then
+                  echo "$same"
+                  exit 1
+                fi
+                same=$(diff existing/chatbot_ui.py "$APP_NAME"/chatbot_ui.py)
+                return_code=$?
+                if [ $return_code != 0 ]; then
+                  echo "$same"
+                  exit 1
+                fi
+                same=$(diff existing/requirements.txt "$APP_NAME"/requirements.txt)
+                return_code=$?
+                if [ $return_code != 0 ]; then
+                  echo "$same"
+                  exit 1
+                fi
+                same=$(diff existing/.tekton/docker-build-ai-software-templates-chart.yaml "$APP_NAME"/.tekton/docker-build-ai-software-templates-chart.yaml)
+                return_code=$?
+                if [ $return_code != 0 ]; then
+                  echo "$same"
+                  exit 1
+                fi
+                same=$(diff existing/.tekton/docker-push.yaml "$APP_NAME"/.tekton/docker-push.yaml)
+                return_code=$?
+                if [ $return_code != 0 ]; then
+                  echo "$same"
+                  exit 1
+                fi
+                same=$(diff existing/.tekton/update-deployment.yaml "$APP_NAME"/.tekton/update-deployment.yaml)
+                return_code=$?
+                if [ $return_code != 0 ]; then
+                  echo "$same"
+                  exit 1
+                fi
+                echo Repo "$GH_REPO" contents OK, exiting.
                 exit 0
               else
                 gh repo create "$GH_REPO" --public --gitignore Python --license Apache-2.0 || exit
@@ -62,27 +127,7 @@ spec:
                 fi
               fi
 
-              gh repo clone "$GITHUB_SOURCE_REPO" app-source -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch
-              gh repo clone "$GITHUB_TETKON_SOURCE_REPO" tekton-source -- --no-tags --single-branch
-              gh repo clone "$GH_REPO" "$APP_NAME" -- --no-tags --branch="$GITHUB_DEFAULT_BRANCH" --single-branch
-
-              mkdir -p "$APP_NAME"/.tekton
-
-              cd tekton-source/pac/pipelineRuns/.tekton || exit
-              sed -i 's@'"$TEKTON_FILE_APP_NAME_REPLACEMENT"'@'"$APP_NAME"'@g' docker-push.yaml
-              sed -i 's@'"$TEKTON_FILE_APP_NAMESPACE_REPLACEMENT"'@'"$APP_NAMESPACE"'@g' docker-push.yaml
-              sed -i 's@'"$TEKTON_FILE_QUAY_ACCOUNT_REPLACEMENT"'@'"$QUAY_ACCOUNT_NAME"'@g' docker-push.yaml
-              cd - || exit
-
-              cd app-source/chatbot || exit
-              tar cf - ./* | (cd ../../"$APP_NAME" || exit; tar xf -)
-              cd ../../tekton-source/pac/pipelineRuns/.tekton || exit
-              tar cf - ./* | (cd ../../../../"$APP_NAME"/.tekton || exit; tar xf -)
-              cd ../../pipelines || exit
-              tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
-              cd ../tasks || exit
-              tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
-              cd ../../../"$APP_NAME" || exit
+              setup_data
 
               author=$(git log -1 --pretty=format:"%aN")
               email=$(git log -1 --pretty=format:"%ae")

--- a/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
+++ b/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
@@ -20,9 +20,10 @@ spec:
               set -o nounset
               set -o pipefail
               cd /tmp || exit
-              wget https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_linux_amd64.tar.gz || exit
-              tar xzf gh_2.62.0_linux_amd64.tar.gz
-              export PATH=$(pwd)/gh_2.62.0_linux_amd64/bin:$PATH
+              wget https://github.com/cli/cli/releases/download/v"$GH_VERSION"/gh_"$GH_VERSION"_linux_amd64.tar.gz || exit
+              tar xzf gh_"$GH_VERSION"_linux_amd64.tar.gz
+              GH_PATH=$(pwd)/gh_"$GH_VERSION"_linux_amd64/bin
+              export PATH="$GH_PATH":"$PATH"
               export SOURCE_REPO_APP_CONTENT_PATH="chatbot"
               export SOURCE_TEKTON_REPO_CONTENT_PATH="pac/pipelineRuns"
               export TEKTON_FILE_APP_NAME_REPLACEMENT="application_name_replace"

--- a/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
+++ b/charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml
@@ -83,11 +83,14 @@ spec:
               tar cf - ./* | (cd ../../../"$APP_NAME"/.tekton || exit; tar xf -)
               cd ../../../"$APP_NAME" || exit
 
-              git config user.email  "{{ .Values.gitops.gitAuthorEmail }}"
-              git config user.name  "{{ .Values.gitops.gitAuthorName }}"
+              author=$(git log -1 --pretty=format:"%aN")
+              email=$(git log -1 --pretty=format:"%ae")
+
+              git config user.email "$email"
+              git config user.name "$author"
 
               git status -s | grep "??" | awk '{ print $2 }' | xargs -l -r git add
-              git commit -a -m initial-commit
+              git commit -a -m "Copy repo content"
               git push origin "$GITHUB_DEFAULT_BRANCH"
 
           image: registry.redhat.io/openshift4/ose-docker-builder-rhel9:v4.16


### PR DESCRIPTION
### What does this PR do?:

This change removes the use of the python GitOps application image defined at https://github.com/redhat-ai-dev/developer-images/tree/main/helm-charts/application-gitops and replaces it with a shell script that performs the GitOps operations directly

In doing so, this script migrated from Python to simple Bash that calls the 'gh' and 'git' commands, using an officially maintained OpenShift Container Platform image hosted at 'registry.redhat.io'.

### Which issue(s) this PR fixes:

https://issues.redhat.com/browse/DEVAI-241


### PR acceptance criteria:

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [/ ] Tested and Verified

The repository https://github.com/gabemontero-appstudio-test-org/ggmtest was created using the helm chart with the new application gitops template defined here.

- [ n/a] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

 