### PR TITLE
Simplify the pipelines configuration process

### DIFF
--- a/docs/PIPELINES_CONFIGURATION.md
+++ b/docs/PIPELINES_CONFIGURATION.md
@@ -1,6 +1,11 @@
 # Openshift Pipelines Configuration Instructions
 
-The OpenShift Pipelines configuration is a requirement in order to support CI/CD between your app's github repository and your application's deployment in OpenShift. To configure the pipelines you'll need to:
+The OpenShift Pipelines configuration is a requirement in order to support CI/CD between your app's github repository and your application's deployment in OpenShift. To configure the pipelines you'll need to follow the steps below. We have separated them into two sections according to the required level of access:
+
+- Cluster admin steps.
+- User/Tenant steps.
+
+## Cluster admin steps.
 
 1. Install the [Openshift Pipelines Operator](https://docs.redhat.com/en/documentation/openshift_container_platform/4.6/html/pipelines/installing-pipelines#installing-pipelines).
 
@@ -39,7 +44,7 @@ kubectl patch secret -n openshift-pipelines signing-secrets -o yaml --patch='{"i
 kubectl api-resources | grep "tektonconfigs"
 ```
 
-7. Update the `TektonConfig`, by enabling the necessary resolvers:
+7. Update the `tektonconfig`, by enabling the necessary resolvers:
 
 ```
 kubectl patch tektonconfig config --type 'merge' --patch "$( cat <<EOF
@@ -61,21 +66,10 @@ EOF
 )"
 ```
 
-8. Create the pipelines secret, containing your Github App's `Webhook URL` and `Webhook Secret`.
+8. Create the `pipelines-as-code-secret`, containing your Github App's `App ID`, `Private Key`, `Webhook Secret`. Note, that your `Private Key` value needs to be passed as a multilined string and not flattened. Additionally, as mentioned in the `pipelines-as-code` documentation, [you can have one Github App connected to your Operator](https://pipelinesascode.com/docs/install/github_apps/). Every tenant in the cluster should install this app on their Github Organization to support the pipeline as code functionality.
 
 ```
-export APP_NAMESPACE=<your-app's namespace>
 export PIPELINES_SECRET_NAME="ai-lab-pipelines-secret"
-export GITHUB_APP_WEBHOOK_SECRET=<your github app's webhook secret>
-export GITHUB_APP_WEBHOOK_URL=<your github app's webhook url>
-kubectl -n "$APP_NAMESPACE" create secret generic "$PIPELINES_SECRET_NAME" \
-    --from-literal="webhook-github-secret=$GITHUB_APP_WEBHOOK_SECRET" \
-    --from-literal="webhook-url=$GITHUB_APP_WEBHOOK_URL"
-```
-
-9. Create the `pipelines-as-code-secret`, containing your Github App's `App ID`, `Private Key`, `Webhook Secret`. Note, that your `Private Key` value needs to be passed as a multilined string and not flattened.
-
-```
 export GITHUB_APP_APP_ID=<your-github-app's-app-id-value>
 export GITHUB_APP_PRIVATE_KEY="
 <your-multi-lined-github-app-private-key>
@@ -86,40 +80,17 @@ kubectl -n openshift-pipelines create secret generic pipelines-as-code-secret \
     --from-literal webhook.secret="$GITHUB_APP_WEBHOOK_SECRET"
 ```
 
-10. Fetch the codesign public key from the `signing-secrets` Secret inside the Operator's Namespace.
+## User/Tenant Steps
+
+1. Create the `ai-lab-image-registry-token` in your application's Namespace, containing the docker `config.json` file of your Quay.io account (see more info [here](https://docs.redhat.com/en/documentation/red_hat_quay/3.6/html-single/use_red_hat_quay/index#allow-robot-access-user-repo)):
 
 ```
-export COSIGN_SIGNING_PUBLIC_KEY=$(kubectl get secrets -n openshift-pipelines signing-secrets -o jsonpath='{.data.cosign\.pub}')
-cat <<EOF | kubectl apply -f - >/dev/null
-apiVersion: v1
-data:
-    cosign.pub: $COSIGN_SIGNING_PUBLIC_KEY
-kind: Secret
-metadata:
-    labels:
-        app.kubernetes.io/instance: default
-        app.kubernetes.io/part-of: tekton-chains
-        operator.tekton.dev/operand-name: tektoncd-chains
-    name: cosign-pub
-    namespace: $APP_NAMESPACE
-type: Opaque
-EOF
-```
-
-11. Create the `pipelines-secret` in your application's Namespace, containing your Github App's `Webhook Secret`:
-
-```
-kubectl -n $APP_NAMESPACE create secret generic pipelines-secret --from-literal=webhook.secret=$GITHUB_APP_WEBHOOK_SECRET
-```
-
-12. Similarly with the previous step, create the `ai-lab-image-registry-token` in your application's Namespace, containing the docker `config.json` file of your Quay.io account (see more info [here](https://docs.redhat.com/en/documentation/red_hat_quay/3.6/html-single/use_red_hat_quay/index#allow-robot-access-user-repo)):
-
-```
+export $APP_NAMESPACE="your-app's namespace"
 export IMAGE_REGISTRY_TOKEN_SECRET="ai-lab-image-registry-token"
 kubectl -n $APP_NAMESPACE create secret docker-registry "$IMAGE_REGISTRY_TOKEN_SECRET" --from-file=.dockerconfigjson=<your-docker-config.json-file-path>
 ```
 
-1.  Patch the `default` and `pipeline` ServiceAccounts in your application Namespace by adding the image registry token secret created above:
+2.  Patch the `default` and `pipeline` ServiceAccounts in your application Namespace by adding the image registry token secret created above:
 
 ```
 for SA in default pipeline; do

--- a/docs/PIPELINES_CONFIGURATION.md
+++ b/docs/PIPELINES_CONFIGURATION.md
@@ -46,8 +46,8 @@ EOF
 5. Create the `pipelines-as-code-secret`, containing your Github App's `App ID`, `Private Key`, `Webhook Secret`. Note, that your `Private Key` value needs to be passed as a multilined string and not flattened. Additionally, as mentioned in the `pipelines-as-code` documentation, [you can have one Github App connected to your Operator](https://pipelinesascode.com/docs/install/github_apps/). Every tenant in the cluster should install this app on their Github Organization to support the pipeline as code functionality.
 
 ```
-export GITHUB_APP_APP_ID=<your-github-app's-app-id-value>
-export GITHUB_APP_WEBHOOK_SECRET=<your-github-app's-webhook-secret>
+export GITHUB_APP_APP_ID="your-github-app's-app-id-value"
+export GITHUB_APP_WEBHOOK_SECRET="your-github-app's-webhook-secret"
 export GITHUB_APP_PRIVATE_KEY="
 <your-multi-lined-github-app-private-key>
 "
@@ -62,7 +62,7 @@ kubectl -n openshift-pipelines create secret generic pipelines-as-code-secret \
 1. Create the `ai-lab-image-registry-token` in your application's Namespace, containing the docker `config.json` file of your Quay.io account (see more info [here](https://docs.redhat.com/en/documentation/red_hat_quay/3.6/html-single/use_red_hat_quay/index#allow-robot-access-user-repo)):
 
 ```
-export $APP_NAMESPACE="your-app's namespace"
+export APP_NAMESPACE="your-app's namespace"
 export IMAGE_REGISTRY_TOKEN_SECRET="ai-lab-image-registry-token"
 kubectl -n $APP_NAMESPACE create secret docker-registry "$IMAGE_REGISTRY_TOKEN_SECRET" --from-file=.dockerconfigjson=<your-docker-config.json-file-path>
 ```

--- a/docs/PIPELINES_CONFIGURATION.md
+++ b/docs/PIPELINES_CONFIGURATION.md
@@ -15,36 +15,13 @@ The OpenShift Pipelines configuration is a requirement in order to support CI/CD
 kubectl get route -n openshift-pipelines pipelines-as-code-controller
 ```
 
-3. Download `cosign` depending on your platform, which will be used to generate the updated `signing-secrets`.
-
-```
-curl -sL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
-```
-
-or
-
-```
-curl -sL https://github.com/sigstore/cosign/releases/latest/download/cosign-darwin-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
-```
-
-4. In the `openshift-pipelines` Namespace, delete (if exists) the `signing-secrets` Secret.
-
-5. Generate the new `signing-secrets` in the `openshift-pipelines` Namespace and patch the new secret as immutable:
-
-```
-export KUBERNETES_SERVICE_PORT=<your-kubernetes-service port>
-export KUBERNETES_SERVICE_HOST=<your-kubernetes-service host>"
-cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
-kubectl patch secret -n openshift-pipelines signing-secrets -o yaml --patch='{"immutable": true}'
-```
-
-6. Ensure that the `tektonconfigs` CRDs are available. You can verify that if the below command returns 1 as response:
+3. Ensure that the `tektonconfigs` CRDs are available. You can verify that if the below command returns 1 as response:
 
 ```
 kubectl api-resources | grep "tektonconfigs"
 ```
 
-7. Update the `tektonconfig`, by enabling the necessary resolvers:
+4. Update the `tektonconfig`, by enabling the necessary resolvers:
 
 ```
 kubectl patch tektonconfig config --type 'merge' --patch "$( cat <<EOF
@@ -66,7 +43,7 @@ EOF
 )"
 ```
 
-8. Create the `pipelines-as-code-secret`, containing your Github App's `App ID`, `Private Key`, `Webhook Secret`. Note, that your `Private Key` value needs to be passed as a multilined string and not flattened. Additionally, as mentioned in the `pipelines-as-code` documentation, [you can have one Github App connected to your Operator](https://pipelinesascode.com/docs/install/github_apps/). Every tenant in the cluster should install this app on their Github Organization to support the pipeline as code functionality.
+5. Create the `pipelines-as-code-secret`, containing your Github App's `App ID`, `Private Key`, `Webhook Secret`. Note, that your `Private Key` value needs to be passed as a multilined string and not flattened. Additionally, as mentioned in the `pipelines-as-code` documentation, [you can have one Github App connected to your Operator](https://pipelinesascode.com/docs/install/github_apps/). Every tenant in the cluster should install this app on their Github Organization to support the pipeline as code functionality.
 
 ```
 export GITHUB_APP_APP_ID=<your-github-app's-app-id-value>

--- a/docs/PIPELINES_CONFIGURATION.md
+++ b/docs/PIPELINES_CONFIGURATION.md
@@ -69,8 +69,8 @@ EOF
 8. Create the `pipelines-as-code-secret`, containing your Github App's `App ID`, `Private Key`, `Webhook Secret`. Note, that your `Private Key` value needs to be passed as a multilined string and not flattened. Additionally, as mentioned in the `pipelines-as-code` documentation, [you can have one Github App connected to your Operator](https://pipelinesascode.com/docs/install/github_apps/). Every tenant in the cluster should install this app on their Github Organization to support the pipeline as code functionality.
 
 ```
-export PIPELINES_SECRET_NAME="ai-lab-pipelines-secret"
 export GITHUB_APP_APP_ID=<your-github-app's-app-id-value>
+export GITHUB_APP_WEBHOOK_SECRET=<your-github-app's-webhook-secret>
 export GITHUB_APP_PRIVATE_KEY="
 <your-multi-lined-github-app-private-key>
 "


### PR DESCRIPTION
### What does this PR do?:

Tries to simplify the configuration process and split the listed steps into two groups, according to the permission level required:

* Steps that have to be executed from a cluster admin.
* Steps that can be executed from the namespace owner.

The PR removes 3 steps in total from the PIPELINES_CONFIGURATION.md guide:
1. The pipeline secret created inside the APP_NAMESPACE.
2. The cosign public key secret inside the APP_NAMESPACE.
3. The generic `pipeline-secret` containing the github app webhook secret inside the APP_NAMESPACE.

### Which issue(s) this PR fixes:

N/A

### PR acceptance criteria:

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

<!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

 <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

### How to test changes / Special notes to the reviewer:

I've tested locally the new configuration instructions and I was able to trigger the pipelineRun and run it successfully:

* My repo is here: https://github.com/fpetk/chatbot-test-261104
* The pipeline is triggered (screenshot below):
![image](https://github.com/user-attachments/assets/7cc3689b-acae-474b-96f9-a1ffac6db1ed)

