### PR TITLE
Finalize generation script

### DIFF
--- a/.github/workflows/update-charts.yaml
+++ b/.github/workflows/update-charts.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Verify updated gitops resources
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  verify-dependencies:
+  verify-updated-gitops-resources:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-charts.yaml
+++ b/.github/workflows/update-charts.yaml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify-dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.1.7
+
+      - name: Run generate.sh and check if the ai-lab-app based charts are up-to-date
+        run: |
+          bash generate.sh
+          if [[ ! -z $(git status -s) ]]
+          then
+            echo 'The script `./generate.sh` did introduce changes, which should ideally be checked in as part of the PR.'
+            git status
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The gitops component, handled by ArgoCD for the RHDH case, is replaced by a Kube
 
 - Creates the GitHub repository for the application.
 - Copies the application source code into the new repository.
-- Copies the Tekton `PipelineRun` that builds new images for the application after pull requests merge or commits are pushed directly to the `main` branch, 
-and then updates the Deployment of the application with the new version of the image by directly patching the Deployment via `oc`, vs. ArgoCD using gitops to patch the Deployment.
+- Copies the Tekton `PipelineRun` that builds new images for the application after pull requests merge or commits are pushed directly to the `main` branch,
+  and then updates the Deployment of the application with the new version of the image by directly patching the Deployment via `oc`, vs. ArgoCD using gitops to patch the Deployment.
 - Commits these changes and pushes the commit to the preferred branch of the new repository.
 
 The source code is [here](charts/ai-software-templates/chatbot/templates/application-gitops-job.yaml).

--- a/charts/ai-software-templates/README.md
+++ b/charts/ai-software-templates/README.md
@@ -6,4 +6,4 @@ Apart from the [pipeline-install](./pipeline-install/) and the [pipeline-setup](
 
 To pull all the latest changes for the charts from the `ai-lab-app` repository you can simply run the `generate.sh` script placed in the root dir of this repository.
 
-The script will clone the `ai-lab-app` and will convert the necessary resources to helm chart template files. Each chart has a corresponding `env` file under `scripts/envs` dir which helps us configure the behavior of the conversion process.
+The script will clone the `ai-lab-app` and will convert the necessary resources to Helm chart template files. Each chart has a corresponding `env` file under the `scripts/envs` dir which helps us configure the behavior of the conversion process.

--- a/charts/ai-software-templates/README.md
+++ b/charts/ai-software-templates/README.md
@@ -1,6 +1,6 @@
 ## ai-software-templates
 
-Apart from the [pipeline-install](./pipeline-install/) and the [pipeline-setup](./pipeline-setup/) which are tools to help you install the tekton pipelines along with your charts, the rest of charts under this directory are based on the [redhat-ai-dev/ai-lab-app](https://github.com/redhat-ai-dev/ai-lab-app) gitops resources repo.
+Apart from the [pipeline-install](./pipeline-install/) and the [pipeline-setup](./pipeline-setup/) which are tools to help you install the Tekton Pipelines along with your charts, the rest of charts under this directory are based on the [redhat-ai-dev/ai-lab-app](https://github.com/redhat-ai-dev/ai-lab-app) gitops resources repo.
 
 ### Pull automatically latest changes
 

--- a/charts/ai-software-templates/README.md
+++ b/charts/ai-software-templates/README.md
@@ -1,0 +1,9 @@
+## ai-software-templates
+
+Apart from the [pipeline-install](./pipeline-install/) and the [pipeline-setup](./pipeline-setup/) which are tools to help you install the tekton pipelines along with your charts, the rest of charts under this directory are based on the [redhat-ai-dev/ai-lab-app](https://github.com/redhat-ai-dev/ai-lab-app) gitops resources repo.
+
+### Pull automatically latest changes
+
+To pull all latest changes for the charts based on `ai-lab-app` you can simply run the `generate.sh` script placed in the root dir of this repository.
+
+The script will clone the `ai-lab-app` and will convert the necessary resources to helm chart template files. Each chart has a corresponding `env` file under `scripts/envs` dir which helps us configure the behavior of the conversion process.

--- a/charts/ai-software-templates/README.md
+++ b/charts/ai-software-templates/README.md
@@ -4,6 +4,6 @@ Apart from the [pipeline-install](./pipeline-install/) and the [pipeline-setup](
 
 ### Pull automatically latest changes
 
-To pull all latest changes for the charts based on `ai-lab-app` you can simply run the `generate.sh` script placed in the root dir of this repository.
+To pull all the latest changes for the charts from the `ai-lab-app` repository you can simply run the `generate.sh` script placed in the root dir of this repository.
 
 The script will clone the `ai-lab-app` and will convert the necessary resources to helm chart template files. Each chart has a corresponding `env` file under `scripts/envs` dir which helps us configure the behavior of the conversion process.

--- a/charts/ai-software-templates/chatbot/Chart.yaml
+++ b/charts/ai-software-templates/chatbot/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 # The name of the chart (required)
 name: chatbot-ai-sample
 # A SemVer 2 version (required)
-version: 0.1.3
+version: 0.1.4
 # A SemVer range of compatible Kubernetes versions (optional)
 kubeVersion: ">= 1.27.0-0"
 # A single-sentence description of this project (optional)

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -1,7 +1,7 @@
 
 
 # Chatbot AI Sample Helm Chart
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This Helm Chart deploys a Large Language Model (LLM)-enabled [chat bot application](https://github.com/redhat-ai-dev/ai-lab-samples/tree/main/chatbot).
 

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -76,14 +76,18 @@ Kubernetes: `>= 1.27.0-0`
 | gitops.gitSourceRepo | string | `"redhat-ai-dev/ai-lab-samples"` | The Github Repository with the contents of the ai-lab sample chatbot application |
 | gitops.githubOrgName | string | `""` | [REQUIRED] The Github Organization name that the chatbot application repository will be created in |
 | gitops.quayAccountName | string | `""` | [REQUIRED] The quay.io account that the application image will be pushed |
-| model.dbRequired | bool | `false` | The bool variable for support of model database |
 | model.existingModelServer | bool | `false` | The bool variable for support of existing model server |
 | model.includeModelEndpointSecret | bool | `false` | The bool variable for support of bearer token authentication for existing model server authentication |
 | model.initContainer | string | `"quay.io/redhat-ai-dev/granite-7b-lab:latest"` | The image used for the initContainer of the model service deployment |
+| model.modelEndpoint | string | `""` | The endpoint url of the model for the existing model service case. Is used only if existingModelServer is set to true. |
+| model.modelEndpointSecretKey | string | `nil` | The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
+| model.modelEndpointSecretName | string | `""` | The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
 | model.modelInitCommand | string | `"['/usr/bin/install', '/model/model.file', '/shared/']"` | The model service initContainer command |
+| model.modelName | string | `""` | The name of the model for the existing model service case. Is used only if existingModelServer is set to true. |
 | model.modelPath | string | `"/model/model.file"` | The path of the model file inside the model service container |
-| model.modelServiceContainer | string | `"quay.io/ai-lab/llamacpp_python:latest"` | The image used for the model service |
+| model.modelServiceContainer | string | `"quay.io/ai-lab/llamacpp_python:latest"` | The image used for the model service. For the VLLM case please see vllmModelServiceContainer |
 | model.modelServicePort | int | `8001` | The exposed port of the model service |
+| model.vllmModelServiceContainer | string | `"quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"` | The image used for the model service for the VLLM use case. |
 | model.vllmSelected | bool | `false` | The bool variable for support of vllms |
 
 **NOTE:** Your helm release's name will be used as the name of the application github repository

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -10,9 +10,9 @@ This Helm Chart deploys a Large Language Model (LLM)-enabled [chat bot applicati
 This Helm Chart creates the following components:
 
 ### The Model Service
-By default the `chatbot-ai-sample` supports the `llama.cpp` inference server and related to the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
+By default the `chatbot-ai-sample` uses the `llama.cpp` inference via the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
 
-However, the usage of `vLLM` model services or existing model services is also supported:
+However, the use of `vLLM` to deploy model services, as well as the use of existing model services is also supported:
 * For the `vLLM` model service case, the `Values.model.vllmSelected` value should be `true`, the `Values.model.vllmModelServiceContainer` and the `Values.model.modelName` should be configured too.
 * For the existing model service case, the `Values.model.existingModelServer` value should be `true` and the `Values.model.modelEndpoint` should be set to the URL of the existing model endpoint we would like to use for this deployment.
 * In case the existing model service requires bearer authentication the `Values.model.includeModelEndpointSecret` should be set to `true`, the `Values.model.modelEndpointSecretName` and the `Values.model.modelEndpointSecretKey` should be configured.

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -80,7 +80,7 @@ Kubernetes: `>= 1.27.0-0`
 | model.includeModelEndpointSecret | bool | `false` | The bool variable for support of bearer token authentication for existing model server authentication |
 | model.initContainer | string | `"quay.io/redhat-ai-dev/granite-7b-lab:latest"` | The image used for the initContainer of the model service deployment |
 | model.modelEndpoint | string | `""` | The endpoint url of the model for the existing model service case. Is used only if existingModelServer is set to true. |
-| model.modelEndpointSecretKey | string | `nil` | The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
+| model.modelEndpointSecretKey | string | `nil` | The name of the secret field storing the bearer value for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
 | model.modelEndpointSecretName | string | `""` | The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
 | model.modelInitCommand | string | `"['/usr/bin/install', '/model/model.file', '/shared/']"` | The model service initContainer command |
 | model.modelName | string | `""` | The name of the model for the existing model service case. Is used only if existingModelServer is set to true. |

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -71,7 +71,7 @@ Kubernetes: `>= 1.27.0-0`
 | application.appContainer | string | `"quay.io/redhat-ai-dev/chatbot:latest"` | The image used for the initial chatbot application interface |
 | application.appPort | int | `8501` | The exposed port of the application |
 | gitops.gitDefaultBranch | string | `"main"` | The default branch for the chatbot application Github repository |
-| gitops.gitSecretKeyToken | string | `"GITHUB_TOKEN"` | The name of the Secret's key with the Github token value |
+| gitops.gitSecretKeyToken | string | `"password"` | The name of the Secret's key with the Github token value |
 | gitops.gitSecretName | string | `"github-secrets"` | The name of the Secret containing the required Github token |
 | gitops.gitSourceRepo | string | `"redhat-ai-dev/ai-lab-samples"` | The Github Repository with the contents of the ai-lab sample chatbot application |
 | gitops.githubOrgName | string | `""` | [REQUIRED] The Github Organization name that the chatbot application repository will be created in |
@@ -79,15 +79,16 @@ Kubernetes: `>= 1.27.0-0`
 | model.existingModelServer | bool | `false` | The bool variable for support of existing model server |
 | model.includeModelEndpointSecret | bool | `false` | The bool variable for support of bearer token authentication for existing model server authentication |
 | model.initContainer | string | `"quay.io/redhat-ai-dev/granite-7b-lab:latest"` | The image used for the initContainer of the model service deployment |
+| model.maxModelLength | int | `4096` | The maximum sequence length of the model. It is used only for the vllm case and the default value is 4096. |
 | model.modelEndpoint | string | `""` | The endpoint url of the model for the existing model service case. Is used only if existingModelServer is set to true. |
 | model.modelEndpointSecretKey | string | `""` | The name of the secret field storing the bearer value for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
 | model.modelEndpointSecretName | string | `""` | The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
 | model.modelInitCommand | string | `"['/usr/bin/install', '/model/model.file', '/shared/']"` | The model service initContainer command |
-| model.modelName | string | `""` | The name of the model for the existing model service case. Is used only if existingModelServer is set to true. |
+| model.modelName | string | `""` | The name of the model. By defaults it is set to instructlab/granite-7b-lab. It is used only for vllm and/or existing model service cases. |
 | model.modelPath | string | `"/model/model.file"` | The path of the model file inside the model service container |
 | model.modelServiceContainer | string | `"quay.io/ai-lab/llamacpp_python:latest"` | The image used for the model service. For the VLLM case please see vllmModelServiceContainer |
 | model.modelServicePort | int | `8001` | The exposed port of the model service |
 | model.vllmModelServiceContainer | string | `""` | The image used for the model service for the VLLM use case. |
-| model.vllmSelected | bool | `false` | The bool variable for support of vllms |
+| model.vllmSelected | bool | `false` | The bool variable for support of vllm instead of llama_cpp. Be sure that your system has GPU support for this case. |
 
 **NOTE:** Your helm release's name will be used as the name of the application github repository

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -80,14 +80,14 @@ Kubernetes: `>= 1.27.0-0`
 | model.includeModelEndpointSecret | bool | `false` | The bool variable for support of bearer token authentication for existing model server authentication |
 | model.initContainer | string | `"quay.io/redhat-ai-dev/granite-7b-lab:latest"` | The image used for the initContainer of the model service deployment |
 | model.modelEndpoint | string | `""` | The endpoint url of the model for the existing model service case. Is used only if existingModelServer is set to true. |
-| model.modelEndpointSecretKey | string | `nil` | The name of the secret field storing the bearer value for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
+| model.modelEndpointSecretKey | string | `""` | The name of the secret field storing the bearer value for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
 | model.modelEndpointSecretName | string | `""` | The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true. |
 | model.modelInitCommand | string | `"['/usr/bin/install', '/model/model.file', '/shared/']"` | The model service initContainer command |
 | model.modelName | string | `""` | The name of the model for the existing model service case. Is used only if existingModelServer is set to true. |
 | model.modelPath | string | `"/model/model.file"` | The path of the model file inside the model service container |
 | model.modelServiceContainer | string | `"quay.io/ai-lab/llamacpp_python:latest"` | The image used for the model service. For the VLLM case please see vllmModelServiceContainer |
 | model.modelServicePort | int | `8001` | The exposed port of the model service |
-| model.vllmModelServiceContainer | string | `"quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"` | The image used for the model service for the VLLM use case. |
+| model.vllmModelServiceContainer | string | `""` | The image used for the model service for the VLLM use case. |
 | model.vllmSelected | bool | `false` | The bool variable for support of vllms |
 
 **NOTE:** Your helm release's name will be used as the name of the application github repository

--- a/charts/ai-software-templates/chatbot/README.md
+++ b/charts/ai-software-templates/chatbot/README.md
@@ -10,7 +10,12 @@ This Helm Chart deploys a Large Language Model (LLM)-enabled [chat bot applicati
 This Helm Chart creates the following components:
 
 ### The Model Service
-Based on the `llama.cpp` inference server and related to the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
+By default the `chatbot-ai-sample` supports the `llama.cpp` inference server and related to the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
+
+However, the usage of `vLLM` model services or existing model services is also supported:
+* For the `vLLM` model service case, the `Values.model.vllmSelected` value should be `true`, the `Values.model.vllmModelServiceContainer` and the `Values.model.modelName` should be configured too.
+* For the existing model service case, the `Values.model.existingModelServer` value should be `true` and the `Values.model.modelEndpoint` should be set to the URL of the existing model endpoint we would like to use for this deployment.
+* In case the existing model service requires bearer authentication the `Values.model.includeModelEndpointSecret` should be set to `true`, the `Values.model.modelEndpointSecretName` and the `Values.model.modelEndpointSecretKey` should be configured.
 
 ### The Application
 A [Streamlit](https://github.com/streamlit/streamlit) application to interact with the model service which is based on the related [Chatbot Template](https://github.com/redhat-ai-dev/ai-lab-template/tree/main/templates/chatbot/content).

--- a/charts/ai-software-templates/chatbot/README.md.gotmpl
+++ b/charts/ai-software-templates/chatbot/README.md.gotmpl
@@ -10,9 +10,9 @@
 This Helm Chart creates the following components:
 
 ### The Model Service
-By default the `chatbot-ai-sample` supports the `llama.cpp` inference server and related to the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
+By default the `chatbot-ai-sample` uses the `llama.cpp` inference via the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
 
-However, the usage of `vLLM` model services or existing model services is also supported:
+However, the use of `vLLM` to deploy model services, as well as the use of existing model services is also supported:
 * For the `vLLM` model service case, the `Values.model.vllmSelected` value should be `true`, the `Values.model.vllmModelServiceContainer` and the `Values.model.modelName` should be configured too. 
 * For the existing model service case, the `Values.model.existingModelServer` value should be `true` and the `Values.model.modelEndpoint` should be set to the URL of the existing model endpoint we would like to use for this deployment.
 * In case the existing model service requires bearer authentication the `Values.model.includeModelEndpointSecret` should be set to `true`, the `Values.model.modelEndpointSecretName` and the `Values.model.modelEndpointSecretKey` should be configured.

--- a/charts/ai-software-templates/chatbot/README.md.gotmpl
+++ b/charts/ai-software-templates/chatbot/README.md.gotmpl
@@ -10,7 +10,12 @@
 This Helm Chart creates the following components:
 
 ### The Model Service
-Based on the `llama.cpp` inference server and related to the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
+By default the `chatbot-ai-sample` supports the `llama.cpp` inference server and related to the [ai-lab-recipes model server](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python).
+
+However, the usage of `vLLM` model services or existing model services is also supported:
+* For the `vLLM` model service case, the `Values.model.vllmSelected` value should be `true`, the `Values.model.vllmModelServiceContainer` and the `Values.model.modelName` should be configured too. 
+* For the existing model service case, the `Values.model.existingModelServer` value should be `true` and the `Values.model.modelEndpoint` should be set to the URL of the existing model endpoint we would like to use for this deployment.
+* In case the existing model service requires bearer authentication the `Values.model.includeModelEndpointSecret` should be set to `true`, the `Values.model.modelEndpointSecretName` and the `Values.model.modelEndpointSecretKey` should be configured.
 
 ### The Application
 A [Streamlit](https://github.com/streamlit/streamlit) application to interact with the model service which is based on the related [Chatbot Template](https://github.com/redhat-ai-dev/ai-lab-template/tree/main/templates/chatbot/content).

--- a/charts/ai-software-templates/chatbot/templates/app-config.yaml
+++ b/charts/ai-software-templates/chatbot/templates/app-config.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}-app-config
     app.kubernetes.io/name:  {{ .Release.Name }}-app-config
@@ -21,3 +18,6 @@ data:
   GITHUB_DEFAULT_BRANCH: "{{ .Values.gitops.gitDefaultBranch }}"
   QUAY_ACCOUNT_NAME: "{{ .Values.gitops.quayAccountName }}"
   GH_VERSION: "2.62.0"
+  INCLUDE_MODEL_ENDPOINT_SECRET: "{{ .Values.model.includeModelEndpointSecret }}"
+  MODEL_ENDPOINT_SECRET_NAME: "{{ .Values.model.modelEndpointSecretName }}"
+  MODEL_ENDPOINT_SECRET_KEY: "{{ .Values.model.modelEndpointSecretKey }}"

--- a/charts/ai-software-templates/chatbot/templates/deployment-model-server.yaml
+++ b/charts/ai-software-templates/chatbot/templates/deployment-model-server.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.model.existingModelServer }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -76,3 +77,4 @@ spec:
         - name: model-file
           emptyDir: {}
       {{ end }}
+{{ end }}

--- a/charts/ai-software-templates/chatbot/templates/deployment-model-server.yaml
+++ b/charts/ai-software-templates/chatbot/templates/deployment-model-server.yaml
@@ -1,87 +1,78 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels: 
+  labels:
     app.kubernetes.io/instance: {{ .Release.Name }}-model-server
-    app.kubernetes.io/name:  {{ .Release.Name }}-model-server
-    app.kubernetes.io/part-of: {{ .Release.Name }}  
+    app.kubernetes.io/name: {{ .Release.Name }}-model-server
+    app.kubernetes.io/part-of: {{ .Release.Name }}
   name: {{ .Release.Name }}-model-server
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/instance:  {{ .Release.Name }}-model-server 
+      app.kubernetes.io/instance: {{ .Release.Name }}-model-server
   template:
-    metadata: 
+    metadata:
       labels:
-        app.kubernetes.io/instance:  {{ .Release.Name }}-model-server
+        app.kubernetes.io/instance: {{ .Release.Name }}-model-server
     spec:
       {{- if or (not .Values.model.vllmSelected) (eq .Values.model.vllmSelected nil) }}
       initContainers:
-      - name: model-file
-        image: {{ .Values.model.initContainer }}
-        command: {{ .Values.model.modelInitCommand }}
-        volumeMounts:
         - name: model-file
-          mountPath: /shared
+          image: {{ .Values.model.initContainer }}
+          command: {{ .Values.model.modelInitCommand }}
+          volumeMounts:
+            - name: model-file
+              mountPath: /shared
       {{ end }}
       containers:
-      {{ if .Values.model.vllmSelected }}
-      - image: {{ .Values.model.vllmModelServiceContainer }}
-        args: [
-            "--model",
-            "{{ .Values.model.modelName }}",
-            "--port",
-            "{{ .Values.model.modelServicePort }}",
-            "--download-dir",
-            "/models-cache",
-            "--max-model-len",
-            "{{values.maxModelLength}}"]
-        resources:
-          limits:
-            nvidia.com/gpu: '1'
-        volumeMounts:
-        - name: dshm
-          mountPath: /dev/shm
-        - name: models-cache
-          mountPath: /models-cache
-      {{ else }}
-      - env:
-        - name: HOST
-          value: "0.0.0.0"
-        - name: PORT
-          value: "{{ .Values.model.modelServicePort }}"
-        - name: MODEL_PATH
-          value: {{ .Values.model.modelPath }}
-        - name: CHAT_FORMAT
-          value: openchat
-        image: {{ .Values.model.modelServiceContainer }}
-        volumeMounts:
-        - name: model-file
-          mountPath: /model
-      {{ end }}
-        name: app-model-service
-        ports:
-        - containerPort: {{ .Values.model.modelServicePort }}
-        securityContext:
-          runAsNonRoot: true
+        {{ if .Values.model.vllmSelected }}
+        - image: {{ .Values.model.vllmModelServiceContainer }}
+          args: ["--model", "{{ .Values.model.modelName }}", "--port", "{{ .Values.model.modelServicePort }}", "--download-dir", "/models-cache", "--max-model-len", "{{values.maxModelLength}}"]
+          resources:
+            limits:
+              nvidia.com/gpu: '1'
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: models-cache
+              mountPath: /models-cache
+        {{ else }}
+        - env:
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "{{ .Values.model.modelServicePort }}"
+            - name: MODEL_PATH
+              value: {{ .Values.model.modelPath }}
+            - name: CHAT_FORMAT
+              value: openchat
+          image: {{ .Values.model.modelServiceContainer }}
+          volumeMounts:
+            - name: model-file
+              mountPath: /model
+              {{ end }}
+          name: app-model-service
+          ports:
+            - containerPort: {{ .Values.model.modelServicePort }}
+          securityContext:
+            runAsNonRoot: true
       {{ if .Values.model.vllmSelected }}
       volumes:
-      - name: dshm
-        emptyDir:
-          medium: Memory
-          sizeLimit: "2Gi"
-      - name: models-cache
-        persistentVolumeClaim:
-          claimName: {{ .Release.Name }}
-
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: "2Gi"
+        - name: models-cache
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}
       tolerations:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
       {{ else }}
       volumes:
-      - name: model-file
-        emptyDir: {}
+        - name: model-file
+          emptyDir: {}
       {{ end }}

--- a/charts/ai-software-templates/chatbot/templates/deployment-model-server.yaml
+++ b/charts/ai-software-templates/chatbot/templates/deployment-model-server.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         {{ if .Values.model.vllmSelected }}
         - image: {{ .Values.model.vllmModelServiceContainer }}
-          args: ["--model", "{{ .Values.model.modelName }}", "--port", "{{ .Values.model.modelServicePort }}", "--download-dir", "/models-cache", "--max-model-len", "{{values.maxModelLength}}"]
+          args: ["--model", "{{ .Values.model.modelName }}", "--port", "{{ .Values.model.modelServicePort }}", "--download-dir", "/models-cache", "--max-model-len", "{{ .Values.model.maxModelLength }}"]
           resources:
             limits:
               nvidia.com/gpu: '1'

--- a/charts/ai-software-templates/chatbot/templates/deployment.yaml
+++ b/charts/ai-software-templates/chatbot/templates/deployment.yaml
@@ -1,46 +1,42 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:  
+  annotations:
     tad.gitops.set/image: ".spec.template.spec.containers[0].image"
     tad.gitops.get/image: ".spec.template.spec.containers[0].image"
     tad.gitops.set/replicas: ".spec.replicas"
-    tad.gitops.get/replicas: ".spec.replicas" 
-  labels: 
+    tad.gitops.get/replicas: ".spec.replicas"
+  labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name:  {{ .Release.Name }}
-    app.kubernetes.io/part-of: {{ .Release.Name }}  
+    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/instance:  {{ .Release.Name }} 
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
-    metadata: 
+    metadata:
       labels:
-        app.kubernetes.io/instance:  {{ .Release.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
-      - image:  {{ .Values.application.appContainer }}
-        name: app-inference
-        envFrom:
-        - configMapRef:
-            name: {{ .Release.Name }}-model-config
-        {{ if .Values.model.dbRequired }}
-        - configMapRef:
-            name: {{ .Release.Name }}-database-config
-        {{ end }}
-        {{ if .Values.model.includeModelEndpointSecret }}
-        env:
-        - name: MODEL_ENDPOINT_BEARER
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.model.modelEndpointSecretName }}
-              key: {{ .Values.model.modelEndpointSecretKey }}
-        {{ end }}
-        ports:
-        - containerPort: {{ .Values.application.appPort }}
-        securityContext:
-          runAsNonRoot: true
+        - image: {{ .Values.application.appContainer }}
+          name: app-inference
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-model-config
+          {{ if .Values.model.includeModelEndpointSecret }}
+          env:
+            - name: MODEL_ENDPOINT_BEARER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.model.modelEndpointSecretName }}
+                  key: {{ .Values.model.modelEndpointSecretKey }}
+          {{ end }}
+          ports:
+            - containerPort: {{ .Values.application.appPort }}
+          securityContext:
+            runAsNonRoot: true

--- a/charts/ai-software-templates/chatbot/templates/pvc.yaml
+++ b/charts/ai-software-templates/chatbot/templates/pvc.yaml
@@ -1,12 +1,11 @@
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  labels: 
+  labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }} 
-  namespace: {{ .Release.Namespace }}
+    app.kubernetes.io/name: {{ .Release.Name }}
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/ai-software-templates/chatbot/templates/route.yaml
+++ b/charts/ai-software-templates/chatbot/templates/route.yaml
@@ -1,11 +1,11 @@
 apiVersion: route.openshift.io/v1
 kind: Route
-metadata: 
-  labels: 
+metadata:
+  labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }} 
-  namespace: {{ .Release.Namespace }}
+    app.kubernetes.io/name: {{ .Release.Name }}
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   port:
     targetPort: {{ .Values.application.appPort }}
@@ -14,6 +14,6 @@ spec:
     termination: edge
   to:
     kind: Service
-    name: {{ .Release.Name }} 
-    weight: 100 
+    name: {{ .Release.Name }}
+    weight: 100
   wildcardPolicy: None

--- a/charts/ai-software-templates/chatbot/templates/service-model-server.yaml
+++ b/charts/ai-software-templates/chatbot/templates/service-model-server.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
-metadata: 
-  labels: 
+metadata:
+  labels:
     app.kubernetes.io/instance: {{ .Release.Name }}-model-server
     app.kubernetes.io/name: {{ .Release.Name }}-model-server
-  namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-model-server
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - port: {{ .Values.model.modelServicePort }}
-    protocol: TCP
-    targetPort: {{ .Values.model.modelServicePort }}
+    - port: {{ .Values.model.modelServicePort }}
+      protocol: TCP
+      targetPort: {{ .Values.model.modelServicePort }}
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}-model-server

--- a/charts/ai-software-templates/chatbot/templates/service-model-server.yaml
+++ b/charts/ai-software-templates/chatbot/templates/service-model-server.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.model.existingModelServer }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       targetPort: {{ .Values.model.modelServicePort }}
   selector:
     app.kubernetes.io/instance: {{ .Release.Name }}-model-server
+{{ end }}

--- a/charts/ai-software-templates/chatbot/templates/service.yaml
+++ b/charts/ai-software-templates/chatbot/templates/service.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
-metadata: 
-  labels: 
+metadata:
+  labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ .Release.Name }} 
-  namespace: {{ .Release.Namespace }}
+    app.kubernetes.io/name: {{ .Release.Name }}
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - port: {{ .Values.application.appPort }}
-    protocol: TCP
-    targetPort: {{ .Values.application.appPort }}
+    - port: {{ .Values.application.appPort }}
+      protocol: TCP
+      targetPort: {{ .Values.application.appPort }}
   selector:
-    app.kubernetes.io/instance: {{ .Release.Name }} 
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/ai-software-templates/chatbot/values.schema.json
+++ b/charts/ai-software-templates/chatbot/values.schema.json
@@ -27,7 +27,7 @@
                     "type": "string"
                 },
                 "gitSecretKeyToken": {
-                    "default": "GITHUB_TOKEN",
+                    "default": "password",
                     "description": "The name of the Secret's key with the Github token value.",
                     "title": "Secret Key Token",
                     "type": "string"

--- a/charts/ai-software-templates/chatbot/values.schema.tmpl.json
+++ b/charts/ai-software-templates/chatbot/values.schema.tmpl.json
@@ -68,7 +68,7 @@
                     "title": "Secret Key Token",
                     "type": "string",
                     "description": "The name of the Secret's key with the Github token value.",
-                    "default": "GITHUB_TOKEN"
+                    "default": "password"
                 },
                 "githubOrgName": {
                     "title": "GitHub Org Name",

--- a/charts/ai-software-templates/chatbot/values.yaml
+++ b/charts/ai-software-templates/chatbot/values.yaml
@@ -15,14 +15,16 @@ model:
   modelServiceContainer: "quay.io/ai-lab/llamacpp_python:latest"
   # -- The exposed port of the model service
   modelServicePort: 8001
-  # -- The bool variable for support of vllms
+  # -- The bool variable for support of vllm instead of llama_cpp. Be sure that your system has GPU support for this case.
   vllmSelected: false
   # -- The image used for the model service for the VLLM use case.
   vllmModelServiceContainer: ""
+  # -- The name of the model. By defaults it is set to instructlab/granite-7b-lab. It is used only for vllm and/or existing model service cases.
+  modelName: ""
+  # -- The maximum sequence length of the model. It is used only for the vllm case and the default value is 4096.
+  maxModelLength: 4096
   # -- The bool variable for support of existing model server
   existingModelServer: false
-  # -- The name of the model for the existing model service case. Is used only if existingModelServer is set to true.
-  modelName: ""
   # -- The endpoint url of the model for the existing model service case. Is used only if existingModelServer is set to true.
   modelEndpoint: ""
   # -- The bool variable for support of bearer token authentication for existing model server authentication
@@ -36,7 +38,7 @@ gitops:
   # -- The name of the Secret containing the required Github token
   gitSecretName: "github-secrets"
   # -- The name of the Secret's key with the Github token value
-  gitSecretKeyToken: "GITHUB_TOKEN"
+  gitSecretKeyToken: "password"
   # -- The Github Repository with the contents of the ai-lab sample chatbot application
   gitSourceRepo: "redhat-ai-dev/ai-lab-samples"
   # -- The default branch for the chatbot application Github repository

--- a/charts/ai-software-templates/chatbot/values.yaml
+++ b/charts/ai-software-templates/chatbot/values.yaml
@@ -11,18 +11,26 @@ model:
   modelInitCommand: "['/usr/bin/install', '/model/model.file', '/shared/']"
   # -- The path of the model file inside the model service container
   modelPath: "/model/model.file"
-  # -- The image used for the model service
+  # -- The image used for the model service. For the VLLM case please see vllmModelServiceContainer
   modelServiceContainer: "quay.io/ai-lab/llamacpp_python:latest"
   # -- The exposed port of the model service
   modelServicePort: 8001
   # -- The bool variable for support of vllms
   vllmSelected: false
-  # -- The bool variable for support of model database
-  dbRequired: false
+  # -- The image used for the model service for the VLLM use case.
+  vllmModelServiceContainer: "quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
   # -- The bool variable for support of existing model server
   existingModelServer: false
+  # -- The name of the model for the existing model service case. Is used only if existingModelServer is set to true.
+  modelName: ""
+  # -- The endpoint url of the model for the existing model service case. Is used only if existingModelServer is set to true.
+  modelEndpoint: ""
   # -- The bool variable for support of bearer token authentication for existing model server authentication
   includeModelEndpointSecret: false
+  # -- The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true.
+  modelEndpointSecretName: ""
+  # -- The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true.
+  modelEndpointSecretKey: 
 
 gitops:
   # -- The name of the Secret containing the required Github token

--- a/charts/ai-software-templates/chatbot/values.yaml
+++ b/charts/ai-software-templates/chatbot/values.yaml
@@ -29,7 +29,7 @@ model:
   includeModelEndpointSecret: false
   # -- The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true.
   modelEndpointSecretName: ""
-  # -- The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true.
+  # -- The name of the secret field storing the bearer value for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true.
   modelEndpointSecretKey: 
 
 gitops:

--- a/charts/ai-software-templates/chatbot/values.yaml
+++ b/charts/ai-software-templates/chatbot/values.yaml
@@ -18,7 +18,7 @@ model:
   # -- The bool variable for support of vllms
   vllmSelected: false
   # -- The image used for the model service for the VLLM use case.
-  vllmModelServiceContainer: "quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
+  vllmModelServiceContainer: ""
   # -- The bool variable for support of existing model server
   existingModelServer: false
   # -- The name of the model for the existing model service case. Is used only if existingModelServer is set to true.
@@ -30,7 +30,7 @@ model:
   # -- The name of the secret storing the credentials for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true.
   modelEndpointSecretName: ""
   # -- The name of the secret field storing the bearer value for the existing model service if the endpoint requires bearer authentication. Is used only if includeModelEndpointSecret is set to true.
-  modelEndpointSecretKey: 
+  modelEndpointSecretKey: ""
 
 gitops:
   # -- The name of the Secret containing the required Github token

--- a/generate.sh
+++ b/generate.sh
@@ -3,4 +3,4 @@
 ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # pull and convert resources from ai-lab-app
-bash $ROOTDIR/scripts/convert-gitops-template.sh
+bash "${ROOTDIR}/scripts/convert-gitops-template.sh"

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# pull and convert resources from ai-lab-app
+bash $ROOTDIR/scripts/convert-gitops-template.sh

--- a/scripts/convert-gitops-template.sh
+++ b/scripts/convert-gitops-template.sh
@@ -64,6 +64,11 @@ convert() {
     # remove blocks related to RAG database - should be supported only for the rag case
     sed -i '/{{ if \.Values\.model\.dbRequired }}/,/{{ end }}/d' "$input_file"
 
+    # add conditional for existing model server for the model-server resources.
+    if [[ $input_file == *"model-server"* ]]; then
+        sed -i '1i {{ if not .Values.model.existingModelServer }}' "$input_file"
+        sed -i '$a {{ end }}' "$input_file"
+    fi
 }
 
 convert_all() {

--- a/scripts/convert-gitops-template.sh
+++ b/scripts/convert-gitops-template.sh
@@ -47,7 +47,7 @@ convert() {
 
     # Add explicit namespace mention
     awk '
-    /name: {{ .Release.Name }}/ && !namespace_added {
+    /  name: {{ .Release.Name }}/ && !namespace_added {
     print $0
     print "  namespace: {{ .Release.Namespace }}"
     namespace_added=1
@@ -59,6 +59,10 @@ convert() {
     # Update conditionals
     sed -E -i 's/\{\{\ if ([^ ]+) or ([^ ]+) \}\}/{{- if or \1 \2 }}/' "$input_file"
     sed -E -i 's/\{\{\ if ([^ ]+) == nil or not\(([^ ]+)\) \}\}/{{- if or (not \1) (eq \2 nil) }}/' "$input_file"
+
+    # remove blocks related to RAG database - should be supported only for the rag case
+    sed -i '/{{ if \.Values\.model\.dbRequired }}/,/{{ end }}/d' "$input_file"
+
 }
 
 convert_all() {

--- a/scripts/convert-gitops-template.sh
+++ b/scripts/convert-gitops-template.sh
@@ -33,6 +33,7 @@ convert() {
     replace "values\.modelEndpointSecretKey" ".Values.model.modelEndpointSecretKey" "$input_file"
     replace "values\.existingModelServer" ".Values.model.existingModelServer" "$input_file"
     replace "values\.dbRequired" ".Values.model.dbRequired" "$input_file"
+    replace "values\.maxModelLength" ".Values.model.maxModelLength" "$input_file"
 
     # Update if conditions
     sed -i 's/{%- if/{{ if/g' "$input_file"


### PR DESCRIPTION
### What does this PR do?:

The PR finalizes the automatic conversion of the shared gitops resources between the `ai-lab-app` and the `ai-lab-helm-chart`.

More specifically it introduces the following updates:

* A script called `generate.sh` is added and is the main point to update all the shared resources. Along with the script a workflow has been added to check in every new PR that we are aligned with the `ai-lab-app` repo. This way we guarantee that both `ai-lab-app` & `ai-lab-samples` are always up-to-date. Finally, a quick readme has been added to capture all this information. I find the best location to be the `ai-software-templates` directory which contains all the related charts.
* In regards to the `chatbot-ai-sample` chart, all the updates brought from https://github.com/redhat-ai-dev/ai-lab-helm-charts/pull/31 are now tested and captured in the readme tmpl (and ofc in the readme) of the chart.
* Finally, the `values.dbRequired` is removed for now from the new resource content as it is only related with the RAG case. I think the best approach here is to create a new chart that will cover this case and not use the chatbot chart for this.

Apart from the above, also some other details are:
* To make sure that the `existingModelServer` will remove the `model-server` deployment if set, the conversion script now adds on the top and bottom of all `*model-server*` files a condition.
* As you can notice some updates are also pulled from ai-lab-app after the formatting [PR](https://github.com/redhat-ai-dev/ai-lab-app/pull/41) that was merged recently.

### Which issue(s) this PR fixes:

Fixes RHDHPAI-379

### PR acceptance criteria:

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

<!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

 <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

### How to test changes / Special notes to the reviewer:

In regards to testing, I've tested the following cases:

* `vLLM` support. If `vllmSelected` is set the model server deployed is based on this technology. To test this case you need to provision a cluster with GPU support:

![image](https://github.com/user-attachments/assets/89ca0bdb-5ba4-4e09-ba58-152e0d7e74b7)

* The existing model server case, along with the bearer authentication support. This skips the model-server deployment and service creation:

![existing-model-server-vs-vllm](https://github.com/user-attachments/assets/de400481-7036-4823-858e-f82fc4f7d83d)

* A test run for the new workflow is [here](https://github.com/thepetk/ai-lab-helm-charts/actions/runs/12994160859/job/36238015683)